### PR TITLE
Centralized calls to GetPlayerAttributes().

### DIFF
--- a/TitanBar/Control/PlayerInfosToolTip.lua
+++ b/TitanBar/Control/PlayerInfosToolTip.lua
@@ -39,7 +39,8 @@ function GetData()
     end;
     
     if PlayerAlign == 1 then
-        Data[3]["name"],Data[3]["value"] = "Armour",comma_value(PlayerAtt:GetArmor());
+        local playerAtt = GetPlayerAttributes();
+        Data[3]["name"],Data[3]["value"] = "Armour",comma_value(playerAtt:GetArmor());
         Data[3]["icon"] = resources.PlayerInfo.Armor;    
         curLvl = Player:GetLevel(); --Current player level
         -- OTHER --
@@ -71,38 +72,38 @@ function GetData()
         end
         -- OTHER END --
         -- STATISTICS --
-        Data[9]["name"],Data[9]["value"] = "Might",PlayerAtt:GetMight();
-        Data[10]["name"],Data[10]["value"] = "Agility",PlayerAtt:GetAgility();
-        Data[11]["name"],Data[11]["value"] = "Vitality",PlayerAtt:GetVitality();
-        Data[12]["name"],Data[12]["value"] = "Will",PlayerAtt:GetWill();
-        Data[13]["name"],Data[13]["value"] = "Fate",PlayerAtt:GetFate();
+        Data[9]["name"],Data[9]["value"] = "Might",playerAtt:GetMight();
+        Data[10]["name"],Data[10]["value"] = "Agility",playerAtt:GetAgility();
+        Data[11]["name"],Data[11]["value"] = "Vitality",playerAtt:GetVitality();
+        Data[12]["name"],Data[12]["value"] = "Will",playerAtt:GetWill();
+        Data[13]["name"],Data[13]["value"] = "Fate",playerAtt:GetFate();
         -- STATISTICS END --
         for i = 9,13 do Data[i]["value"] = comma_value(Data[i]["value"]); end
         PlayerAttArray = {}; -- array[i] = {"Visible label name", value, "formula category", "penetration debuff"};
         -- for i = 14,33 do PlayerAttArray[i] = {} end; 
-        PlayerAttArray[22] = {"Physical", PlayerAtt:GetCommonMitigation(), "ComPhyMit", "Armour"}; -- common physical
-        PlayerAttArray[23] = {"Tactical", PlayerAtt:GetTacticalMitigation(), "TacMit", "Armour"}; -- tactical
-        PlayerAttArray[24] = {"Orc", PlayerAtt:GetPhysicalMitigation(), "NonPhyMit", "Armour"}; -- non-common physical
-        PlayerAttArray[25] = {"Fell", PlayerAtt:GetPhysicalMitigation(), "NonPhyMit", "Armour"}; -- non-common physical
-        PlayerAttArray[20] = {"Outgoing", PlayerAtt:GetOutgoingHealing(), "OutHeal", nil};
-        PlayerAttArray[21] = {"Incoming", PlayerAtt:GetIncomingHealing(), "InHeal", nil};
-        PlayerAttArray[14] = {"Melee", PlayerAtt:GetMeleeDamage(), "PhyDmg", nil};
-        PlayerAttArray[15] = {"Ranged", PlayerAtt:GetRangeDamage(), "PhyDmg", nil};
-        PlayerAttArray[16] = {"Tactical", PlayerAtt:GetTacticalDamage(), "TacDmg", nil};
-        PlayerAttArray[17] = {"CritHit", PlayerAtt:GetBaseCriticalHitChance(), "CritHit", nil};
-        PlayerAttArray[18] = {"DevHit", PlayerAtt:GetBaseCriticalHitChance(), "DevHit", nil};
-        PlayerAttArray[19] = {"Finesse", PlayerAtt:GetFinesse(), "Finesse", nil};
-        PlayerAttArray[26] = {"CritDef", PlayerAtt:GetBaseCriticalHitAvoidance(), "CritDef", nil};
-        PlayerAttArray[27] = {"Resistances", PlayerAtt:GetBaseResistance(), "Resist", "Resist"};
-        PlayerAttArray[28] = {"Block", PlayerAtt:GetBlock(), "Block", "BPE"};
-        PlayerAttArray[29] = {"Partial", PlayerAtt:GetBlock(), "PartBlock", "BPE"};
-        PlayerAttArray[30] = {"PartMit", PlayerAtt:GetBlock(), "PartBlockMit", "BPE"};
-        PlayerAttArray[31] = {"Parry", PlayerAtt:GetParry(), "Parry", "BPE"};
-        PlayerAttArray[32] = {"Partial", PlayerAtt:GetParry(), "PartParry", "BPE"};
-        PlayerAttArray[33] = {"PartMit", PlayerAtt:GetParry(), "PartParryMit", "BPE"};
-        PlayerAttArray[34] = {"Evade", PlayerAtt:GetEvade(), "Evade", "BPE"};
-        PlayerAttArray[35] = {"Partial", PlayerAtt:GetEvade(), "PartEvade", "BPE"};
-        PlayerAttArray[36] = {"PartMit", PlayerAtt:GetEvade(), "PartEvadeMit", "BPE"};
+        PlayerAttArray[22] = {"Physical", playerAtt:GetCommonMitigation(), "ComPhyMit", "Armour"}; -- common physical
+        PlayerAttArray[23] = {"Tactical", playerAtt:GetTacticalMitigation(), "TacMit", "Armour"}; -- tactical
+        PlayerAttArray[24] = {"Orc", playerAtt:GetPhysicalMitigation(), "NonPhyMit", "Armour"}; -- non-common physical
+        PlayerAttArray[25] = {"Fell", playerAtt:GetPhysicalMitigation(), "NonPhyMit", "Armour"}; -- non-common physical
+        PlayerAttArray[20] = {"Outgoing", playerAtt:GetOutgoingHealing(), "OutHeal", nil};
+        PlayerAttArray[21] = {"Incoming", playerAtt:GetIncomingHealing(), "InHeal", nil};
+        PlayerAttArray[14] = {"Melee", playerAtt:GetMeleeDamage(), "PhyDmg", nil};
+        PlayerAttArray[15] = {"Ranged", playerAtt:GetRangeDamage(), "PhyDmg", nil};
+        PlayerAttArray[16] = {"Tactical", playerAtt:GetTacticalDamage(), "TacDmg", nil};
+        PlayerAttArray[17] = {"CritHit", playerAtt:GetBaseCriticalHitChance(), "CritHit", nil};
+        PlayerAttArray[18] = {"DevHit", playerAtt:GetBaseCriticalHitChance(), "DevHit", nil};
+        PlayerAttArray[19] = {"Finesse", playerAtt:GetFinesse(), "Finesse", nil};
+        PlayerAttArray[26] = {"CritDef", playerAtt:GetBaseCriticalHitAvoidance(), "CritDef", nil};
+        PlayerAttArray[27] = {"Resistances", playerAtt:GetBaseResistance(), "Resist", "Resist"};
+        PlayerAttArray[28] = {"Block", playerAtt:GetBlock(), "Block", "BPE"};
+        PlayerAttArray[29] = {"Partial", playerAtt:GetBlock(), "PartBlock", "BPE"};
+        PlayerAttArray[30] = {"PartMit", playerAtt:GetBlock(), "PartBlockMit", "BPE"};
+        PlayerAttArray[31] = {"Parry", playerAtt:GetParry(), "Parry", "BPE"};
+        PlayerAttArray[32] = {"Partial", playerAtt:GetParry(), "PartParry", "BPE"};
+        PlayerAttArray[33] = {"PartMit", playerAtt:GetParry(), "PartParryMit", "BPE"};
+        PlayerAttArray[34] = {"Evade", playerAtt:GetEvade(), "Evade", "BPE"};
+        PlayerAttArray[35] = {"Partial", playerAtt:GetEvade(), "PartEvade", "BPE"};
+        PlayerAttArray[36] = {"PartMit", playerAtt:GetEvade(), "PartEvadeMit", "BPE"};
         if (useCalcStat) then
             local CSClassName = CalcStat("ClassName",PlayerClassIdIs);
             local CDCanBlock = CSClassName ~= "" and CalcStat(CSClassName.."CDCanBlock",curLvl) or 1;

--- a/TitanBar/Control/WalletToolTip.lua
+++ b/TitanBar/Control/WalletToolTip.lua
@@ -48,7 +48,7 @@ function RefreshWITTListBox()
 				ttw = _G.CurrencyData[v.name].Where
 				CtrIconCodeIs=WalletItem[v.name].Icon
 				if wttcur == L["MDestinyPoints"] then
-					CtrQteIs = PlayerAtt:GetDestinyPoints()
+					CtrQteIs = GetPlayerAttributes():GetDestinyPoints()
 				else
 					CtrQteIs=GetCurrency(L["M" .. v.name]);
 				end
@@ -68,7 +68,7 @@ function RefreshWITTListBox()
 
 			if wttcur == L["MGSC"] then --Money control
 				local wiPosX, tmWidth = 0, 0;
-				local wmoney = PlayerAtt:GetMoney();
+				local wmoney = GetPlayerAttributes():GetMoney();
 				DecryptMoney(wmoney);
 				local twmoney = { gold, silver, copper };
 				--local twmoneyi = { 0x41007e7b, 0x41007e7c, 0x41007e7d }; --gold, silver, copper icon 27x21

--- a/TitanBar/functions.lua
+++ b/TitanBar/functions.lua
@@ -174,7 +174,7 @@ end
 --**v Update money on TitanBar v**
 function UpdateMoney()
 	if _G.MIWhere == 1 then
-		local money = PlayerAtt:GetMoney();
+		local money = GetPlayerAttributes():GetMoney();
 		DecryptMoney(money);
 	
 		MI[ "GLbl" ]:SetText( string.format( "%.0f", gold ) );
@@ -290,7 +290,7 @@ end
 function UpdateCurrencyDisplay(currencyName)
 	if _G.CurrencyData[currencyName].Where == 1 then
 		if currencyName == "DestinyPoints" then
-			_G.CurrencyData[currencyName].Lbl:SetText(PlayerAtt:GetDestinyPoints())
+			_G.CurrencyData[currencyName].Lbl:SetText(GetPlayerAttributes():GetDestinyPoints())
 		else
 			_G.CurrencyData[currencyName].Lbl:SetText(GetCurrency(L["M"..currencyName]))
 		end
@@ -803,4 +803,16 @@ function GetTotalItems( MyTable )
 	local counter = 0;
 	for k, v in pairs( MyTable ) do counter = counter + 1; end
 	return counter;
+end
+
+PlayerAtt = nil;
+---Central function to handle calling Player:GetAttributes().
+---(The first time GetAttributes is called, the LOTRO client hangs for a short period,
+---so we want to initialize it as-needed instead of on plugin load.)
+---@return Attributes | FreePeopleAttributes
+function GetPlayerAttributes()
+    if (PlayerAtt == nil) then
+        PlayerAtt = Player:GetAttributes();
+    end
+    return PlayerAtt;
 end

--- a/TitanBar/functionsCtr.lua
+++ b/TitanBar/functionsCtr.lua
@@ -16,15 +16,14 @@ function ImportCtr( value )
             MI[ "Ctr" ]:SetPosition( _G.MILocX, _G.MILocY );
         end
         if _G.MIWhere ~= 3 then
-            PlayerAtt = Player:GetAttributes();
-            AddCallback(PlayerAtt, "MoneyChanged",
+            AddCallback(GetPlayerAttributes(), "MoneyChanged",
                 function(sender, args) UpdateMoney(); end
                 );
             AddCallback(sspack, "CountChanged", UpdateSharedStorageGold);
             -- ^^ Thx Heridian!
             UpdateMoney();
         else
-            RemoveCallback(PlayerAtt, "MoneyChanged");
+            RemoveCallback(GetPlayerAttributes(), "MoneyChanged");
             RemoveCallback(sspack, "CountChanged", UpdateSharedStorageGold);
             -- ^^ Thx Heridian!
         end
@@ -47,7 +46,6 @@ function ImportCtr( value )
     elseif value == "PI" then --Player Infos
         import (AppCtrD.."PlayerInfos");
         import (AppCtrD.."PlayerInfosToolTip");
-        PlayerAtt = Player:GetAttributes();
         AddCallback(Player, "LevelChanged",
             function(sender, args)
                 PI["Lvl"]:SetText( Player:GetLevel() );
@@ -403,14 +401,13 @@ function ImportCtr( value )
         end
         if _G.CurrencyData[value].Where ~= 3 then
             if value == "DestinyPoints" then
-                PlayerAtt = Player:GetAttributes();
-                AddCallback(PlayerAtt, "DestinyPointsChanged", function(sender, args)
+                AddCallback(GetPlayerAttributes(), "DestinyPointsChanged", function(sender, args)
                     UpdateCurrencyDisplay("DestinyPoints")
                 end)
             end
             UpdateCurrencyDisplay(value)
         elseif value == "DestinyPoints" then
-            RemoveCallback(PlayerAtt, "DestinyPointsChanged")
+            RemoveCallback(GetPlayerAttributes(), "DestinyPointsChanged")
         end
     end
 end
@@ -524,7 +521,6 @@ function LoadPlayerMoney()
     if wallet == nil then wallet = {}; end
 
     local PN = Player:GetName();
-    local PlayerAtt = Player:GetAttributes();
 
     if wallet[PN] == nil then wallet[PN] = {}; end
     if wallet[PN].Show == nil then wallet[PN].Show = true; end
@@ -596,8 +592,9 @@ function LoadPlayerMoney()
         walletStats[DOY][PN].TotSpent = "0";
         walletStats[DOY][PN].SumTS = "0";
     end
-    walletStats[DOY][PN].Start = tostring(PlayerAtt:GetMoney());
-    walletStats[DOY][PN].Had = tostring(PlayerAtt:GetMoney());
+    local playerAtt = GetPlayerAttributes();
+    walletStats[DOY][PN].Start = tostring(playerAtt:GetMoney());
+    walletStats[DOY][PN].Had = tostring(playerAtt:GetMoney());
     walletStats[DOY][PN].Earned = "0";
     walletStats[DOY][PN].Spent = "0";
     walletStats[DOY][PN].SumSS = "0";
@@ -613,7 +610,7 @@ function SavePlayerMoney( save )
 
     wallet[PN].Show = _G.SCM;
     wallet[PN].ShowToAll = _G.SCMA;
-    wallet[PN].Money = tostring( PlayerAtt:GetMoney() );
+    wallet[PN].Money = tostring( GetPlayerAttributes():GetMoney() );
 
     -- Calculate Gold/Silver/Copper Total
     GoldTot, SilverTot, CopperTot = 0, 0, 0;


### PR DESCRIPTION
Centralizing the various initializations of PlayerAtt, because at least one place that uses it doesn't initialize it.

(And if it's centrally located you can return a mock object if you are working in a piece of the code that doesn't use PlayerAtt and you don't want to take the multi-second hit every time you load the plugin.) 