### PR TITLE
Fixed the mismatch in spelling betwen GiftgiversBrand and GiftGiversBrand

### DIFF
--- a/TitanBar/Locale/de.lua
+++ b/TitanBar/Locale/de.lua
@@ -92,8 +92,8 @@ L[ "StarsOfMerith" ] = "Eure Sterne des Verdienst";
 L[ "MCentralGondorSilverPiece" ] = "Zentralgondorisches Silberst\195\188ck";
 L[ "CentralGondorSilverPieceh" ] = "Eure Zentralgondorischen Silberst\195\188cke";
 -- Gift giver's Brand control
-L[ "MGiftgiversBrand" ] = "Zeichen des Schenkenden";
-L[ "GiftgiversBrandh" ] = "Eure Zeichen des Schenkenden";
+L[ "MGiftGiversBrand" ] = "Zeichen des Schenkenden";
+L[ "GiftGiversBrandh" ] = "Eure Zeichen des Schenkenden";
 -- Motes of Enchantment control
 L[ "MMotesOfEnchantment" ] = "Staub der Verzauberung";
 L[ "MotesOfEnchantmenth" ] = "Euer Staub der Verzauberung";

--- a/TitanBar/Locale/en.lua
+++ b/TitanBar/Locale/en.lua
@@ -92,8 +92,8 @@ L[ "StarsOfMerith" ] = "These are your Stars of Merit";
 L[ "MCentralGondorSilverPiece" ] = "Central Gondor Silver Piece";
 L[ "CentralGondorSilverPieceh" ] = "These are your Central Gondor Silver Pieces";
 -- Gift giver's Brand control
-L[ "MGiftgiversBrand" ] = "Gift-giver's Brand";
-L[ "GiftgiversBrandh" ] = "These are your Gift-giver's Brands";
+L[ "MGiftGiversBrand" ] = "Gift-giver's Brand";
+L[ "GiftGiversBrandh" ] = "These are your Gift-giver's Brands";
 -- Motes of Enchantment control
 L[ "MMotesOfEnchantment" ] = "Motes of Enchantment";
 L[ "MotesOfEnchantmenth" ] = "These are your Motes of Enchantment";

--- a/TitanBar/Locale/fr.lua
+++ b/TitanBar/Locale/fr.lua
@@ -92,8 +92,8 @@ L[ "StarsOfMerith" ] = "Ce sont vos \195\137toiles du m\195\169rite";
 L[ "MCentralGondorSilverPiece" ] = "Pi\195\168ce d'argent du Gondor central";
 L[ "CentralGondorSilverPieceh" ] = "Ce sont vos Pi\195\168ces d'argent du gondor Central";
 -- Gift giver's Brand control
-L[ "MGiftgiversBrand" ] = "Marque du Donateur";
-L[ "GiftgiversBrandh" ] = "Ce sont vos Marques du Donateur";
+L[ "MGiftGiversBrand" ] = "Marque du Donateur";
+L[ "GiftGiversBrandh" ] = "Ce sont vos Marques du Donateur";
 -- Motes of Enchantment control
 L[ "MMotesOfEnchantment" ] = "Grain d\226\128\153enchantement";
 L[ "MotesOfEnchantmenth" ] = "Ce sont vos Grains d'Enchantement";

--- a/TitanBar/main.lua
+++ b/TitanBar/main.lua
@@ -106,7 +106,7 @@ if PlayerAlign == 1 then
 		-- Item Advancement
 		L["MShards"],
 		-- Other   
-		L["MAmrothSilverPiece"], L["MBingoBadge"], L["MCentralGondorSilverPiece"], L["MEastGondorSilverPiece"], L["MGiftgiversBrand"], L["MTokensOfHytbold"], L["MColdIronToken"],
+		L["MAmrothSilverPiece"], L["MBingoBadge"], L["MCentralGondorSilverPiece"], L["MEastGondorSilverPiece"], L["MGiftGiversBrand"], L["MTokensOfHytbold"], L["MColdIronToken"],
 		L["MMedallionOfMoria"], L["MMedallionOfLothlorien"], L["MTokenOfHeroism"], L["MHerosMark"], L["MGabilakkaWarMark"], L["MSteelToken"],
 		L["MCopperCoinOfGundabad"], L["MSilverCoinOfGundabad"], L["MIronCoinOfCardolan"], L["MBreeLandWoodMark"], L["MBronzeArnorianCoin"],
 		L["MSilverArnorianCoin"], L["MGreyfloodMark"], L["MGundabadMountainMark"], L["MSilverTokenOfTheRiddermark"], L["MGoldenTokenOfTheRiddermark"],
@@ -148,7 +148,7 @@ _G.CurrencyLangMap = { -- reverse lookup table necessary to get the internal ite
   [L["MAmrothSilverPiece"]] = "AmrothSilverPiece",
 	[L["MBingoBadge"]] = "BingoBadge",
 	[L["MCentralGondorSilverPiece"]] = "CentralGondorSilverPiece",
-	[L["MGiftgiversBrand"]] = "GiftgiversBrand",
+	[L["MGiftGiversBrand"]] = "GiftGiversBrand",
 	[L["MTokensOfHytbold"]] = "TokensOfHytbold",
 	[L["MColdIronToken"]] = "ColdIronToken",
 	[L["MTokenOfHeroism"]] = "TokenOfHeroism",


### PR DESCRIPTION
I picked GiftGiversBrand so that TitanBar doesn't appear to forget any settings the player might have regarding this currency.